### PR TITLE
[FIXUP] Fixed project build as submodule of another CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 # Add NE10 library sub-directory.
 add_subdirectory(modules)
 
+target_include_directories(NE10 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+
 if(NE10_BUILD_EXAMPLES AND NE10_ENABLE_MATH)
     add_subdirectory(samples)
 endif()


### PR DESCRIPTION
This PR fixes NE10 includes consuming if NE10 is compiled as a submodule of another CMake project